### PR TITLE
feat: add support for additional patterns via CLI arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,18 +31,34 @@ npmprune
 
 If the `NODE_ENV` environment variable is set to `production`, NPMprune performs a more extensive cleanup by also removing type definitions.
 
+### Additional Patterns
+
+You can provide additional patterns by passing them as arguments:
+
+```sh
+npmprune "*.log" "*.bak"
+```
+
 ## Integration
 
 ### In deployment scripts
 
 ```sh
+# Basic usage:
 wget -qO- https://raw.githubusercontent.com/xthezealot/npmprune/master/npmprune.sh | sh
+
+# With additional patterns:
+wget -qO- https://raw.githubusercontent.com/xthezealot/npmprune/master/npmprune.sh | sh -s -- "*.log" "*.bak"
 ```
 
 ### In a Dockerfile
 
 ```dockerfile
+# Basic usage:
 RUN wget -qO- https://raw.githubusercontent.com/xthezealot/npmprune/master/npmprune.sh | sh
+
+# With additional patterns:
+RUN wget -qO- https://raw.githubusercontent.com/xthezealot/npmprune/master/npmprune.sh | sh -s -- "*.log" "*.bak"
 ```
 
 # Compatibility

--- a/npmprune.sh
+++ b/npmprune.sh
@@ -83,6 +83,11 @@ PROD_PATTERNS="
 	*.ts
 "
 
+# Add patterns from command-line arguments.
+for arg in "$@"; do
+    PATTERNS="$PATTERNS $arg"
+done
+
 if [ "$NODE_ENV" = "production" ]; then
 	PATTERNS="$PATTERNS $PROD_PATTERNS"
 fi

--- a/npmprune.sh
+++ b/npmprune.sh
@@ -83,10 +83,8 @@ PROD_PATTERNS="
 	*.ts
 "
 
-# Add patterns from command-line arguments.
-for arg in "$@"; do
-    PATTERNS="$PATTERNS $arg"
-done
+# Add patterns from command-line arguments
+[ "$#" -gt 0 ] && PATTERNS="$PATTERNS $(printf '\n%s' "$@")"
 
 if [ "$NODE_ENV" = "production" ]; then
 	PATTERNS="$PATTERNS $PROD_PATTERNS"


### PR DESCRIPTION
### Context

I reviewed the feedback provided on #3 , and I agree with all of the comments made there.

One [specific point](https://github.com/xthezealot/npmprune/pull/3#discussion_r1438166954) raised was about the `images` folder and file patterns.

Through my own experience, I've noticed that many repositories include unnecessary images (e.g., `.png`, `.gif`, `.jpeg`) in their `node_modules`. These are often documentation assets that provide no real value in production environments. For example: [promise-retry](https://www.npmjs.com/package/promise-retry) -  [pino](https://www.npmjs.com/package/pino), [fluent-ffmpeg](https://www.npmjs.com/package/fluent-ffmpeg) ...

Moreover, this is a common approach seen in other tools like [serverless-plugin-common-excludes](https://github.com/dougmoscrop/serverless-plugin-common-excludes/blob/master/common-excludes.js), where such files are excluded by default.

---

### Proposal

To address this in a flexible and non-breaking way, this Merge Request introduces the ability to add patterns manually via CLI arguments. 

This change allows me (and other users) to exclude unnecessary image (or other) files without imposing this behavior on everyone. For example, I can now ignore image files like this:

```sh
npmprune "*.png" "*.gif" "*.jpeg"
```

